### PR TITLE
Prevent z-index value changes

### DIFF
--- a/gulp/build.js
+++ b/gulp/build.js
@@ -33,7 +33,7 @@ gulp.task('html', ['inject', 'partials'], function () {
         .pipe(cssFilter)
         .pipe($.rev())
         .pipe($.sourcemaps.init())
-        .pipe($.cssnano())
+        .pipe($.cssnano({ zindex: false }))
         .pipe($.sourcemaps.write('maps'))
         .pipe(cssFilter.restore)
         .pipe($.revReplace())


### PR DESCRIPTION
I had a problem with angular-toastr module in prod, because cssnano was changing z-index value to 1, the toast was showing behind nav, luckily the navbar was transparent and i managed to see the problem, adding this opcion to cssnano will fix the issue