### PR TITLE
normalize-css/.bower.json doesnt specify main filename.

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -129,6 +129,11 @@ config.plugins.uglifyAngularLocales = {
  */
 config.plugins.wiredep = {
   directory: 'bower_components',
+  overrides:{
+    "normalize-css":{
+      "main":["normalize.css"]
+    }
+  }
 };
 
 /**


### PR DESCRIPTION
fixed with Wiredep configuration overriding.